### PR TITLE
Changing the random_password parameter number 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "random_password" "secret" {
   special     = false
   min_upper   = 1
   min_lower   = 1
-  number      = var.include_numbers
+  numeric      = var.include_numbers
 }
 
 resource "aws_secretsmanager_secret" "secret" {


### PR DESCRIPTION
Changing the random_password parameter number to numeric to alleviate warnings in plan. Here's an example of a plan prior (with no changes to the secret):

```
│ Warning: Argument is deprecated
│ 
│   with module.user_secrets.random_password.secret,
│   on .terraform/modules/user_secrets/main.tf line 7, in resource "random_password" "secret":
│    7:   number      = var.include_numbers
│ 
│ Use numeric instead.
│ 
│ (and one more similar warning elsewhere)
╵
```

This is the YL stack I want to use this in:
https://bitbucket.org/youngliving/terraform-database/src/806cced3a76f237d6a208ce1d919da1603099158/stacks/sqlcommon/main.tf#lines-128

I am starting some maintenance on this stack and if I can get rid of some of these warnings prior, it will help cut the noise. 

Please publish a new tag. Thank you
